### PR TITLE
Fix for Emacs 28

### DIFF
--- a/lisp/header-file.el
+++ b/lisp/header-file.el
@@ -31,6 +31,7 @@
 
 ;;; Code:
 (require 'find-file)
+(require 'cl-macs)
 
 (defconst header-file-mode-version "0.2" "Version of `header-file-mode'.")
 


### PR DESCRIPTION
Emacs 28 removed `ff-other-file-name`, so now we have to monkey-patch the package and call `ff-find-the-other-file` instead.